### PR TITLE
Added open tags to header

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -29,4 +29,5 @@
   <% if (theme.highlight){ %>
     <%- css('css/highlight') %>
   <% } %>
+  <%- open_graph() -%>
 </head>


### PR DESCRIPTION
Added a call to Hexo's [open_graph](https://hexo.io/docs/helpers.html?spm=a2c6h.14275010.0.0.56f9c8983lqcYQ#open-graph) helper in order to include the Open Graphs tags to the head of the page.